### PR TITLE
Add a default height and width to BMÅ logo (SVG version).

### DIFF
--- a/bma.svg
+++ b/bma.svg
@@ -1,7 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- Generator: Adobe Illustrator 26.5.0, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
-<svg version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
-	 viewBox="0 0 362.6 362.6" style="enable-background:new 0 0 362.6 362.6;" xml:space="preserve">
+<svg version="1.1" xmlns="http://www.w3.org/2000/svg"
+	 xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
+	 height="363px" width="363px" viewBox="0 0 362.6 362.6"
+	 style="enable-background:new 0 0 362.6 362.6;"
+	 xml:space="preserve">
 <style type="text/css">
 	.st0{fill:#3AAA35;}
 	.st1{fill:#FFCC00;}


### PR DESCRIPTION
When using an SVG in a img tag Firefox will look for a default size in the SVG and use that. If no setting is found it defaults to 0.